### PR TITLE
Fix several things that were broken in recent revisions.

### DIFF
--- a/doc/css/sample-problem.css
+++ b/doc/css/sample-problem.css
@@ -1,27 +1,27 @@
 pre.CodeMirror {
-  background-color: #fcfaf1;
+	background-color: #fcfaf1;
 }
 .explanation {
-  --bs-code-color: #971556;
+	--bs-code-color: #971556;
 }
 .preamble {
-  background-color: lightblue;
+	background-color: lightblue;
 }
 .setup {
-  background-color: #ddffdd;
+	background-color: #ddffdd;
 }
 .statement {
-  background-color: #eeb08199;
+	background-color: #eeb08199;
 }
 .answer {
-  background-color: #ffffdd;
+	background-color: #ffffdd;
 }
 .solution {
-  background-color: #ffb6c199;
+	background-color: #ffb6c199;
 }
 .hint {
-  background-color: rgb(239, 207, 251);
+	background-color: rgb(239, 207, 251);
 }
 .perl {
-  color: darkred;
+	color: darkred;
 }

--- a/doc/sample-problems/Algebra/GraphToolCircle.pg
+++ b/doc/sample-problems/Algebra/GraphToolCircle.pg
@@ -47,15 +47,16 @@ loadMacros('PGstandard.pl', 'PGML.pl', 'parserGraphTool.pl', 'PGcourse.pl');
 #: The `->with` method is then used to set options for the `GraphTool` object.
 #: In this case the options that are set are:
 #:
-#: * `bbox`: this is an array reference of four values xmin, ymax, xmax, ymin
+#: * `bBox`: This is an array reference of four values xmin, ymax, xmax, ymin
 #: indicating the upper left and lower right corners of the visible graph.
 #:
 #: There is a default checker for the GraphTool that will mark correct a
-#: student answer that 'looks' like the correct one.  This means that if
+#: student answer that 'looks' like the correct one. This means that if
 #: a student adds two circles that are equivalent with one solid and one
 #: dashed, that if the solid one is plotted second, credit will be given.
-#: For simple graphs, the default should be sufficient.  If not see
-#: XXXX for an example with a custom answer checker.
+#: For simple graphs, the default should be sufficient. See
+#: PROBLINK('GraphToolCustomChecker.pg') for an example of how to use a custom
+#: checker.
 #:
 #: For more details, see the PODLINK('POD documentation','parserGraphTool.pl')
 $h = non_zero_random(-5, 5);

--- a/doc/sample-problems/Algebra/GraphToolCubic.pg
+++ b/doc/sample-problems/Algebra/GraphToolCubic.pg
@@ -1,5 +1,5 @@
 ## DESCRIPTION
-## Interactive graphing tool problem that asks the student to plot a circle.
+## Interactive graphing tool problem that asks the student to plot a cubic.
 ## ENDDESCRIPTION
 
 ## DBsubject(WeBWorK)
@@ -16,13 +16,16 @@
 #:% categories = [graph]
 
 #:% section = preamble
-#: This example shows how to get student input in the form of a graph (a circle)
+#: This example shows how to get student input in the form of a graph (a cubic)
 #: by using interactive graphing tools. Load the parserGraphTool.pl macro for
 #: this.
 DOCUMENT();
 
-loadMacros('PGstandard.pl', 'PGML.pl', 'parserGraphTool.pl',
-  'contextFraction.pl','PGcourse.pl');
+loadMacros(
+    'PGstandard.pl',      'PGML.pl',
+    'parserGraphTool.pl', 'contextFraction.pl',
+    'PGcourse.pl'
+);
 
 #:% section = setup
 #: A cubic is created with 3 random zeros and a random y-intercept.
@@ -33,21 +36,21 @@ loadMacros('PGstandard.pl', 'PGML.pl', 'parserGraphTool.pl',
 #: of the attributes of the object. The first attribute in each list is the
 #: type of object to be graphed, `cubic` in this case. What the remaining
 #: attributes are depend on the type. For a cubic the second attribute is
-#: whether the object is to be `solid` or `dashed`, the remaining arguments
-#: are the 4 points of the cubic.
+#: whether the object is to be `solid` or `dashed`, the remaining attributes
+#: are four distinct points of the cubic.
 #:
 #: The `->with` method is then used to set options for the `GraphTool` object.
 #: In this case the options that are set are:
 #:
-#: * bbox: this is an array reference of four values xmin, ymax, xmax, ymin
+#: * `bBox`: This is an array reference of four values xmin, ymax, xmax, ymin
 #: indicating the upper left and lower right corners of the visible graph.
-#  * availableTools: this determines which tools should be shown on the
-#: graph tool.
+#: * `availableTools`: This determines which tools will be available for the
+#: student to use.
 #:
 #: There is a default checker for the GraphTool that will mark correct a
-#: student answer that 'looks' like the correct one.  For simple graphs,
-#: the default should be sufficient.  If not see
-#: XXXX for an example with a custom answer checker.
+#: student answer that 'looks' like the correct one. For simple graphs,
+#: the default should be sufficient. See PROBLINK('GraphToolCustomChecker.pg')
+#: for an example of how to use a custom checker.
 
 Context('Fraction');
 
@@ -55,16 +58,20 @@ $x1 = random(-8, -4);
 $x2 = non_zero_random(-3, -3);
 $x3 = random(4, 8);
 
-$y0 = non_zero_random(-3,3);
+$y0 = non_zero_random(-3, 3);
 
-$k = Fraction($y0,-$x1*$x2*$x3);
+$k = Fraction($y0, -$x1 * $x2 * $x3);
 
-
-$gt = GraphTool("{cubic, solid, ($x1, 0), ($x2, 0), ($x3, 0), (0, $y0)}")->with(
-	bBox           => [ -11, 11, 11, -11 ],
-	availableTools =>
-		[ 'PointTool', 'LineTool', 'CircleTool', 'QuadraticTool', 'CubicTool', 'FillTool', 'SolidDashTool' ],
-);
+$gt =
+    GraphTool("{cubic, solid, ($x1, 0), ($x2, 0), ($x3, 0), (0, $y0)}")->with(
+        bBox           => [ -11, 11, 11, -11 ],
+        availableTools => [
+            'PointTool',  'LineTool',
+            'CircleTool', 'QuadraticTool',
+            'CubicTool',  'FillTool',
+            'SolidDashTool'
+        ],
+    );
 
 #:% section = statement
 #: This asks to graph the cubic throw the given points. The code

--- a/doc/sample-problems/Algebra/GraphToolCustomChecker.pg
+++ b/doc/sample-problems/Algebra/GraphToolCustomChecker.pg
@@ -1,5 +1,5 @@
 ## DESCRIPTION
-## Interactive graphing tool problems.
+## Interactive graphing tool problem with a custom checker.
 ## ENDDESCRIPTION
 
 ## DBsubject(WeBWorK)
@@ -10,15 +10,15 @@
 ## Author(Glenn Rice)
 ## KEYWORDS('graphs', 'circles')
 
-#:% name = Interactive graphing tool problems
+#:% name = Graph Tool, custom checker
 #:% type = [Sample, technique]
 #:% subject = [algebra, precalculus]
 #:% categories = [graph]
 
 #:% section = preamble
 #: This example shows how to get student input in the form of a graph (a circle)
-#: by using interactive graphing tools. Load the parserGraphTool.pl macro for
-#: this.
+#: by using interactive graphing tools, and demonstrates the usage of a custom
+#: checker.  Load the parserGraphTool.pl macro for this.
 DOCUMENT();
 
 loadMacros('PGstandard.pl', 'PGML.pl', 'parserGraphTool.pl', 'PGcourse.pl');
@@ -28,10 +28,10 @@ loadMacros('PGstandard.pl', 'PGML.pl', 'parserGraphTool.pl', 'PGcourse.pl');
 #:
 #: The lines
 #:
-#:```{#equation .perl}
+#: ```{#equation .perl}
 #: Context()->variables->add(y => 'Real');
 #: $circle_eq_lhs = Formula("(x - $h)^2 + (y - $k)^2")->reduce;
-#:```
+#: ```
 #:
 #: define the equation of the circle that is shown in the problem and solution.
 #:
@@ -47,16 +47,16 @@ loadMacros('PGstandard.pl', 'PGML.pl', 'parserGraphTool.pl', 'PGcourse.pl');
 #: The `->with` method is then used to set options for the `GraphTool` object.
 #: In this case the options that are set are:
 #:
-#: * bbox: this is an array reference of four values xmin, ymax, xmax, ymin
+#: * `bBox`: this is an array reference of four values xmin, ymax, xmax, ymin
 #: indicating the upper left and lower right corners of the visible graph.
-#: * cmpOptions: this is a hash of options passed to the cmp method for checking
+#: * `cmpOptions`: this is a hash of options passed to the cmp method for checking
 #: the answer.
 #:
 #: The option
 #:
-#:```{#cmp-options .perl}
+#: ```{#cmp-options .perl}
 #: cmpOptions => { list_checker => sub { ... } }
-#:```
+#: ```
 #:
 #: defines a list checker. The list checker is passed the `$correct` answer
 #: which will be a MathObject list of lists containing the attributes of the
@@ -75,68 +75,68 @@ Context()->variables->add(y => 'Real');
 $circle_eq_lhs = Formula("(x - $h)^2 + (y - $k)^2")->reduce;
 
 $gt = GraphTool("{circle, solid, ($h, $k), ($h + $r, $k)}")->with(
-	bBox       => [ -11, 11, 11, -11 ],
-	cmpOptions => {
-		list_checker => sub {
-			my ($correct, $student, $ans, $value) = @_;
-			return 0 if $ans->{isPreview};
+    bBox       => [ -11, 11, 11, -11 ],
+    cmpOptions => {
+        list_checker => sub {
+            my ($correct, $student, $ans, $value) = @_;
+            return 0 if $ans->{isPreview};
 
-			my $score = 0;
-			my @errors;
-			my $count = 1;
+            my $score = 0;
+            my @errors;
+            my $count = 1;
 
-			# Get the center and point that define the correct circle and
-			# compute the square of the radius.
-			my ($cx, $cy) = $correct->[0]->extract(3)->value;
-			my ($px, $py) = $correct->[0]->extract(4)->value;
-			my $r_squared = ($cx - $px)**2 + ($cy - $py)**2;
+            # Get the center and point that define the correct circle and
+            # compute the square of the radius.
+            my ($cx, $cy) = $correct->[0]->extract(3)->value;
+            my ($px, $py) = $correct->[0]->extract(4)->value;
+            my $r_squared = ($cx - $px)**2 + ($cy - $py)**2;
 
-			my $pointOnCircle = sub {
-				my $point = shift;
-				my ($x, $y) = $point->value;
-				return ($x - $cx)**2 + ($y - $cy)**2 == $r_squared;
-			};
+            my $pointOnCircle = sub {
+                my $point = shift;
+                my ($x, $y) = $point->value;
+                return ($x - $cx)**2 + ($y - $cy)**2 == $r_squared;
+            };
 
-			# Iterate through the objects the student graphed and check to
-			# see if each is the correct circle.
-			for (@$student) {
-				my $nth = Value::List->NameForNumber($count++);
+            # Iterate through the objects the student graphed and check to
+            # see if each is the correct circle.
+            for (@$student) {
+                my $nth = Value::List->NameForNumber($count++);
 
-				# This checks if the object graphed by the student is the same
-				# type as the correct object type (a circle in this case),
-				# has the same solid or dashed status, has the same center, and
-				# if the other point graphed is on the circle.
-				if ($_->extract(1) eq $correct->[0]->extract(1)
-					&& $_->extract(2) eq $correct->[0]->extract(2)
-					&& $_->extract(3) == $correct->[0]->extract(3)
-					&& $pointOnCircle->($_->extract(4)))
-				{
-					$score += 1;
-					next;
-				}
+                # This checks if the object graphed by the student is the same
+                # type as the correct object type (a circle in this case),
+                # has the same solid or dashed status, has the same center, and
+                # if the other point graphed is on the circle.
+                if ($_->extract(1) eq $correct->[0]->extract(1)
+                    && $_->extract(2) eq $correct->[0]->extract(2)
+                    && $_->extract(3) == $correct->[0]->extract(3)
+                    && $pointOnCircle->($_->extract(4)))
+                {
+                    $score += 1;
+                    next;
+                }
 
-				# Add messages for incorrect answers.
+                # Add messages for incorrect answers.
 
-				if ($_->extract(1) ne $correct->[0]->extract(1)) {
-					push(@errors,
-						"The $nth object graphed is not a circle");
-					next;
-				}
+                if ($_->extract(1) ne $correct->[0]->extract(1)) {
+                    push(@errors,
+                        "The $nth object graphed is not a circle");
+                    next;
+                }
 
-				if ($_->extract(2) ne $correct->[0]->extract(2)) {
-					push(@errors,
-						"The $nth object graphed should be a "
-							. $correct->[0]->extract(2)
-							. " circle.");
-					next;
-				}
+                if ($_->extract(2) ne $correct->[0]->extract(2)) {
+                    push(@errors,
+                        "The $nth object graphed should be a "
+                            . $correct->[0]->extract(2)
+                            . " circle.");
+                    next;
+                }
 
-				push(@errors, "The $nth object graphed is incorrect.");
-			}
+                push(@errors, "The $nth object graphed is incorrect.");
+            }
 
-			return ($score, @errors);
-		}
-	}
+            return ($score, @errors);
+        }
+    }
 );
 
 #:% section = statement

--- a/doc/sample-problems/Algebra/GraphToolLine.pg
+++ b/doc/sample-problems/Algebra/GraphToolLine.pg
@@ -1,5 +1,5 @@
 ## DESCRIPTION
-## Interactive graphing tool problem that asks the student to plot a circle.
+## Interactive graphing tool problem that asks the student to plot a line.
 ## ENDDESCRIPTION
 
 ## DBsubject(WeBWorK)
@@ -16,13 +16,12 @@
 #:% categories = [graph]
 
 #:% section = preamble
-#: This example shows how to get student input in the form of a graph (a circle)
+#: This example shows how to get student input in the form of a graph (a line)
 #: by using interactive graphing tools. Load the parserGraphTool.pl macro for
 #: this.
 DOCUMENT();
 
-loadMacros('PGstandard.pl', 'PGML.pl', 'parserGraphTool.pl',
-  'PGcourse.pl');
+loadMacros('PGstandard.pl', 'PGML.pl', 'parserGraphTool.pl', 'PGcourse.pl');
 
 #:% section = setup
 #: A cubic is created with 3 random zeros and a random y-intercept.
@@ -31,35 +30,37 @@ loadMacros('PGstandard.pl', 'PGML.pl', 'parserGraphTool.pl',
 #: the correct answer. This is a string that contains a list of objects that
 #: the student will be expected to graph. Each object is a brace delimited list
 #: of the attributes of the object. The first attribute in each list is the
-#: type of object to be graphed, `cubic` in this case. What the remaining
-#: attributes are depend on the type. For a cubic the second attribute is
-#: whether the object is to be `solid` or `dashed`, the remaining arguments
-#: are the 4 points of the cubic.
+#: type of object to be graphed, `line` in this case. What the remaining
+#: attributes are depend on the type. For a line the second attribute is
+#: whether the object is to be `solid` or `dashed`, and the remaining attibutes
+#: are two distinct points on the line.
 #:
 #: The `->with` method is then used to set options for the `GraphTool` object.
 #: In this case the options that are set are:
 #:
-#: * bbox: this is an array reference of four values xmin, ymax, xmax, ymin
+#: * `bBox`: This is an array reference of four values xmin, ymax, xmax, ymin
 #: indicating the upper left and lower right corners of the visible graph.
-#  * availableTools: this determines which tools should be shown on the
-#: graph tool.
+#: * `availableTools`: This determines which tools will be available for the
+#: student to use.
 #:
 #: There is a default checker for the GraphTool that will mark correct a
-#: student answer that 'looks' like the correct one.  For simple graphs,
-#: the default should be sufficient.  If not see
-#: XXXX for an example with a custom answer checker.
+#: student answer that 'looks' like the correct one. For simple graphs,
+#: the default should be sufficient. See PROBLINK('GraphToolCustomChecker.pg')
+#: for an example of how to use a custom checker.
 
-$x0 = non_zero_random(-6,6);
-$y0 = non_zero_random(-6,6);
-$line = nicestring([$y0,$x0],['x','y']);
-
+$x0   = non_zero_random(-6, 6);
+$y0   = non_zero_random(-6, 6);
+$line = nicestring([ $y0, $x0 ], [ 'x', 'y' ]);
 
 $gt = GraphTool("{line, solid, ($x0, 0), (0, $y0)}")->with(
-	bBox           => [ -11, 11, 11, -11 ],
-	availableTools =>
-		[ 'PointTool', 'LineTool', 'CircleTool', 'QuadraticTool', 'CubicTool', 'FillTool', 'SolidDashTool' ],
+    bBox           => [ -11, 11, 11, -11 ],
+    availableTools => [
+        'PointTool',  'LineTool',
+        'CircleTool', 'QuadraticTool',
+        'CubicTool',  'FillTool',
+        'SolidDashTool'
+    ],
 );
-
 
 #:% section = statement.
 #: The code `[_]{$gt}` inserts the GraphTool.
@@ -87,6 +88,5 @@ and thus the [`x`]-intercept is number in the fraction under the [`x`] or
 [@ $gt->generateAnswerGraph @]*
 
 END_PGML_SOLUTION
-
 
 ENDDOCUMENT();

--- a/doc/sample-problems/Algebra/GraphToolNumberLine.pg
+++ b/doc/sample-problems/Algebra/GraphToolNumberLine.pg
@@ -16,61 +16,58 @@
 #:% categories = [graph]
 
 #:% section = preamble
-#: This example shows how to get student input in the form of a graph (a circle)
+#: This example shows how to get student input in the form of a graph
 #: by using interactive graphing tools. Load the `parserGraphTool.pl` macro for
 #: this.
 DOCUMENT();
 
-loadMacros('PGstandard.pl', 'PGML.pl', 'parserGraphTool.pl',
-  'PGcourse.pl');
-
+loadMacros('PGstandard.pl', 'PGML.pl', 'parserGraphTool.pl', 'PGcourse.pl');
 
 #:% section = setup
-#: There are two different intervals created with random enpoints.  The first
-#: one is finite, the second an infinite interval.
+#: Two intervals are created with random enpoints. The first
+#: one is a bounded interval, and the second an unbounded interval.
 #:
 #: The `GraphTool` method creates the graph tool object. The only argument is
 #: the correct answer. This is a string that contains a list of objects that
 #: the student will be expected to graph. Each object is a brace delimited list
 #: of the attributes of the object. The first attribute in each list is the
-#: type of object to be graphed, `interval` in this case. What the remaining
-#: attributes are depend on the type and for this case, enter the interval
-#: in standard interval notation.
+#: type of object to be graphed, `interval` in this case. The remaining
+#: attributes depend on the type of graph object. For an `interval`, there is
+#: only one attribute which is the interval in standard interval notation.
 #:
 #: The `->with` method is then used to set options for the `GraphTool` object.
 #: In this case the options that are set are:
 #:
-#: * numberLine is set to 1 (true) to indicate this is a one-dimensional
+#: * `numberLine` is set to 1 (true) to indicate this is a one-dimensional
 #: graph.
-#: * bbox: since we are using an number the bounding box is just an array
-#: reference [xmin, xmax]
-#  * availableTools: this determines which tools should be shown on the
-#: graph tool.
-#: ticksDistanceX: indicates the distance between tick marks in the x direction
-#: minorTicksX: indicates the distance of subticks. The value 0 means no
-#: subticks.
-#: * useBracketEnds: 1 (true) means to use () and [] to denote the intervals
+#: * `bBox`: For a number line the bounding box is an array reference [xmin, xmax]
+#: containing the left and right limits of the visible graph.
+#: * `availableTools`: This determines which tools will be available for the
+#: student to use.
+#: * `ticksDistanceX`: The distance between tick marks in the x direction.
+#: * `minorTicksX`: The number of minor ticks to show. This can be 0.
+#: * `useBracketEnds`: 1 (true) means to use () and [] to denote the intervals
 #: a value of 0 means to use open and solid circles.
 $x1 = random(1, 5);
 
-$gt1 = GraphTool("{interval,(-$x1,$x1]}")->with(
-	availableTools => [ 'PointTool', 'IntervalTool', 'IncludeExcludePointTool' ],
-	numberLine     => 1,
-	bBox           => [ -6, 6 ],
-	ticksDistanceX => 1,
-	minorTicksX    => 0,
-	useBracketEnds => 1
+$gt1 = GraphTool("{interval, (-$x1,$x1]}")->with(
+    availableTools => [ 'PointTool', 'IntervalTool', 'IncludeExcludePointTool' ],
+    numberLine     => 1,
+    bBox           => [ -6, 6 ],
+    ticksDistanceX => 1,
+    minorTicksX    => 0,
+    useBracketEnds => 1
 );
 
-$x2 = random(-5,5);
+$x2 = random(-5, 5);
 
-$gt2 = GraphTool("{interval,(-inf,$x2)}")->with(
-	availableTools => [ 'PointTool', 'IntervalTool', 'IncludeExcludePointTool' ],
-	numberLine     => 1,
-	bBox           => [ -6, 6 ],
-	ticksDistanceX => 1,
-	minorTicksX    => 0,
-	useBracketEnds => 0
+$gt2 = GraphTool("{interval, (-inf,$x2)}")->with(
+    availableTools => [ 'PointTool', 'IntervalTool', 'IncludeExcludePointTool' ],
+    numberLine     => 1,
+    bBox           => [ -6, 6 ],
+    ticksDistanceX => 1,
+    minorTicksX    => 0,
+    useBracketEnds => 0
 );
 
 #:% section = statement.
@@ -84,6 +81,5 @@ Graph the solution set for the linear inequality [`x < [$x2]`].
 
 [_]{$gt2}
 END_PGML
-
 
 ENDDOCUMENT();

--- a/doc/sample-problems/Algebra/GraphToolPoints.pg
+++ b/doc/sample-problems/Algebra/GraphToolPoints.pg
@@ -1,5 +1,5 @@
 ## DESCRIPTION
-## Interactive graphing tool problem that asks the student to plot a circle.
+## Interactive graphing tool problem that asks the student to plot points.
 ## ENDDESCRIPTION
 
 ## DBsubject(WeBWorK)
@@ -22,8 +22,7 @@
 #: this.
 DOCUMENT();
 
-loadMacros('PGstandard.pl', 'PGML.pl', 'parserGraphTool.pl',
-  'PGcourse.pl');
+loadMacros('PGstandard.pl', 'PGML.pl', 'parserGraphTool.pl', 'PGcourse.pl');
 
 #:% section = setup
 #: Two points are created at random.
@@ -33,18 +32,18 @@ loadMacros('PGstandard.pl', 'PGML.pl', 'parserGraphTool.pl',
 #: the student will be expected to graph. Each object is a brace delimited list
 #: of the attributes of the object. The first attribute in each list is the
 #: type of object to be graphed, `point` in this case. What the remaining
-#: attributes are depend on the type. For a point, it is just the coordinates
-#: in standard form.
+#: attributes are depend on the type. For a point, there is only one additional
+#: attribute which is the point itself.
 #:
 #: The `->with` method is then used to set options for the `GraphTool` object.
 #: In this case the options that are set are:
 #:
-#: * `bbox`: this is an array reference of four values `xmin, ymax, xmax, ymin`
+#: * `bBox`: This is an array reference of four values `xmin, ymax, xmax, ymin`
 #: indicating the upper left and lower right corners of the visible graph.
-#: * `availableTools`: this determines which tools should be shown on the
-#: graph tool.
-#: * `showCoordinatesHints`: the 0 turns off coordinate hints, which would show
-#: students the coordinates the cursor is on.
+#: * `availableTools`: This determines which tools will be available for the
+#: student to use.
+#: * `showCoordinateHints`: Setting this to 0 turns off coordinate hints, which
+#: would show students the coordinates the cursor is over.
 #:
 #: For more details, see the PODLINK('POD documentation','parserGraphTool.pl')
 $x1 = non_zero_random(-5, 5);
@@ -54,9 +53,9 @@ $x2 = non_zero_random(-5, 5);
 $y2 = non_zero_random(-5, 5);
 
 $gt = GraphTool("{point, ($x1, $y1)}", "{point, ($x2, $y2)}")->with(
-	availableTools      => ['PointTool'],
-	bBox                => [ -11, 11, 11, -11 ],
-	showCoordinateHints => 0,
+    availableTools      => ['PointTool'],
+    bBox                => [ -11, 11, 11, -11 ],
+    showCoordinateHints => 0,
 );
 
 #:% section = statement.

--- a/doc/sample-problems/macro_pod.yaml
+++ b/doc/sample-problems/macro_pod.yaml
@@ -26,11 +26,11 @@ macros:
   niceTables.pl: ui/niceTables.html
 
   parserAssignment.pl: parsers/parserAssignment.html
+  parserAutoStrings.pl: parser/parserAutoStrings.pl
   parserCheckboxList.pl: parsers/parserCheckboxList.html
   parserDifferenceQuotient.pl: parsers/parserDifferenceQuotient.html
   parserFormulaUpToConstant.pl: parsers/parserFormulaUpToConstant.html
   parserFormulaWithUnits.pl: parsers/parserFormulaWithUnits.html
-  parserFormulaUpToConstant.pl: parsers/parserFormulaUpToConstant.html
   parserFunction.pl: parsers/parserFunction.html
   parserGraphTool.pl: graph/parserGraphTool.html
   parserImplicitEquation.pl: parsers/parserImplicitEquation.html

--- a/doc/templates/general-layout.mt
+++ b/doc/templates/general-layout.mt
@@ -14,11 +14,11 @@
 			margin-top: 70px;
 		}
 		#sidebar {
-			--bs-offcanvas-width: 300px;
+			--bs-offcanvas-width: 320px;
 		}
 		@media only screen and (min-width: 768px) {
 			#sidebar {
-				width: 275px;
+				width: 320px;
 				height: calc(100vh - 70px);
 			}
 		}
@@ -35,7 +35,8 @@
 						data-bs-toggle="dropdown" aria-expanded="false">
 						<%= $active eq 'categories' ? 'Sample Problems'
 							: $active eq 'techniques' ? 'Problem Techniques'
-							: 'Subject Area Problems' =%>
+							: $active eq 'subjects' ? 'Subject Area Problems'
+							: 'Problems by Macro' =%>
 					</a>
 					<ul class="dropdown-menu">
 						<li>

--- a/doc/templates/general-main.mt
+++ b/doc/templates/general-main.mt
@@ -1,7 +1,3 @@
-<div class="tab-pane fade active show" style="font-size:120%; font-style: italic;"
-	id="default" role="tabpanel" aria-labelledby="default-tab" tabindex="0">
-Select a link to the left to see a list of problems.
-</div>
 % for (sort(keys %$list)) {
 	% my $id = $_ =~ s/\s/_/gr;
 	<div class="tab-pane fade" id="<%= $id %>" role="tabpanel" aria-labelledby="<%= $id %>-tab"

--- a/doc/templates/general-sidebar.mt
+++ b/doc/templates/general-sidebar.mt
@@ -1,15 +1,13 @@
 <div class="offcanvas-header">
-	<h2 class="offcanvas-title fs-3" id="sidebar-label"><%=$label=%></h2>
+	<h2 class="offcanvas-title fs-3" id="sidebar-label"><%= $label =%></h2>
 	<button type="button" class="btn-close" data-bs-dismiss="offcanvas"
 		data-bs-target="#sidebar" aria-label="Close">
 	</button>
 </div>
 
-<h2 class="fs-3 d-none d-md-block px-3 pt-3"><%=$label=%></h2>
+<h2 class="fs-3 d-none d-md-block px-3 pt-3"><%= $label =%></h2>
 <div class="offcanvas-body px-md-3 pb-md-3 w-100">
 	<div class="list-group w-100" role="tablist" id="sidebar-list">
-		<a style="display: none" class="list-group-item list-group-item-action active" id="default-tab" href="#default"
-			data-bs-toggle="list" role="tab" aria-controls="default">Default</a>
 		% for (sort(keys %$list)) {
 			% my $id = $_ =~ s/\s/_/gr;
 			<a class="list-group-item list-group-item-action" id="<%= $id %>-tab" href="#<%= $id %>"

--- a/doc/templates/problem-template.mt
+++ b/doc/templates/problem-template.mt
@@ -8,7 +8,6 @@
 
 	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/css/bootstrap.min.css" rel="stylesheet">
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.65.11/lib/codemirror.min.css">
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.56.0/theme/eclipse.min.css">
 	<script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.11/addon/runmode/runmode-standalone.min.js" defer>
 	</script>
 	<script src="<%= $home %>/PG.js" defer></script>
@@ -17,12 +16,12 @@
 
 % # Default explanations
 % my $default = {
-%	preamble => 'These standard macros need to be loaded.',
-% setup => 'This perl code sets up the problem.',
-% statement => 'This is the problem statement in PGML.',
-% answer => 'This is used for answer checking.',
-% solution => 'A solution should be provided here.'
-%};
+	% preamble => 'These standard macros need to be loaded.',
+	% setup => 'This perl code sets up the problem.',
+	% statement => 'This is the problem statement in PGML.',
+	% answer => 'This is used for answer checking.',
+	% solution => 'A solution should be provided here.'
+% };
 
 <body>
 	<div class="container-fluid p-3">
@@ -61,7 +60,11 @@
 				<h2>See Also</h2>
 				<ul>
 					% for (@$related) {
-						<li><a href="<%= $home =%>/<%= $_->{dir} =%>/<%= $_->{file} =~ s/.pg$//r =%>.html"><%= $_->{name} =%></a></li>
+						<li>
+							<a href="<%= $home =%>/<%= $_->{dir} =%>/<%= $_->{file} =~ s/\.pg$//r =%>.html">
+								<%= $_->{name} =%>
+							</a>
+						</li>
 					% }
 				</ul>
 			</div>
@@ -81,7 +84,7 @@
 							<path fill-rule="evenodd" d="M10 1.5a.5.5 0 0 0-.5-.5h-3a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-1Zm-5 0A1.5 1.5 0 0 1 6.5 0h3A1.5 1.5 0 0 1 11 1.5v1A1.5 1.5 0 0 1 9.5 4h-3A1.5 1.5 0 0 1 5 2.5v-1Zm-2 0h1v1A2.5 2.5 0 0 0 6.5 5h3A2.5 2.5 0 0 0 12 2.5v-1h1a2 2 0 0 1 2 2V14a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V3.5a2 2 0 0 1 2-2Z"/>
 						</svg>
 					</button>
-					<pre class="CodeMirror cm-s-eclipse m-0 h-100 p-3 border border-secondary overflow-x-scroll"><%== $_->{code} %></pre>
+					<pre class="CodeMirror cm-s-default m-0 h-100 p-3 border border-secondary overflow-x-scroll"><%== $_->{code} %></pre>
 				</div>
 				<div class="explanation <%= $_->{section} %> col-sm-12 col-md-6 order-md-last order-first border border-dark">
 					<p><b><%= ucfirst($_->{section}) %></b></p>

--- a/doc/templates/techniques-main.mt
+++ b/doc/templates/techniques-main.mt
@@ -1,7 +1,3 @@
-<div class="tab-pane fade active show" style="font-size:120%; font-style: italic;"
-	id="default" role="tabpanel" aria-labelledby="default-tab" tabindex="0">
-Select a link to the left to see a list of problems.
-</div>
 % for (['A' .. 'C'], ['D' .. 'F'], ['G' .. 'Z']) {
 	<div class="tab-pane fade" id="<%= $_->[0] %>" role="tabpanel" aria-labelledby="<%= $_->[0] %>-tab" tabindex="0">
 		<h1 class="fs-3">Sample Problems for Techniques: <%= $_->[0] %> .. <%= $_->[-1] %></h1>

--- a/doc/templates/techniques-sidebar.mt
+++ b/doc/templates/techniques-sidebar.mt
@@ -7,8 +7,6 @@
 
 <div class="offcanvas-body p-md-3 w-100">
 	<div class="list-group w-100" role="tablist" id="sidebar-list">
-	<a style="display: none" class="list-group-item list-group-item-action active" id="default-tab" href="#default"
-			data-bs-toggle="list" role="tab" aria-controls="default">Default</a>
 		% for (['A' .. 'C'], ['D' .. 'F'], ['G' .. 'Z']) {
 			<a class="list-group-item list-group-item-action" id="<%= $_->[0] %>-tab" href="#<%= $_->[0] %>"
 				data-bs-toggle="list" role="tab" aria-controls="<%= $_->[0] %>">


### PR DESCRIPTION
Remove the CodeMirror eclipse theme, and just use the default.  This is the same default used in the PGProblemEditor for webwork2, and is actually very similar to the eclipse theme.  If you don't like the dark theme, then we should just use the default.

Increase the width of the sidebar to fit the content.

Make the dropdown show the correct label when the macros page is selected.

Remove the "default" tab pane and hidden sidebar item.  The instructions that were in the tab pane simply aren't needed.  This is a straightforward page with not much else to do.  In addition the hidden list-group-item completely messes up the sidebar appearance.

Remove the duplicate "parserFormulaUpToConstant.pl" key in macro_pod.yml, and add the missing "parserAutoStrings.pl" macro that is referenced in "doc/sample-problems/problem-techniques/StringsInContext.pg".  Since this was not in the yml file, this caused a use of uninitialized value in string concatenation warning, and obviously the link didn't work.

Also fix several issues with the documentation in the graph tool problems.