### PR TITLE
add a promote to the SigFig macro to handle other expressions

### DIFF
--- a/macros/contexts/contextSignificantFigures.pl
+++ b/macros/contexts/contextSignificantFigures.pl
@@ -293,6 +293,17 @@ sub neg {
 	return $self->new(-$self->value, sigfigs => $self->{sigfigs});
 }
 
+# This promotes non-Sig fig numbers that are used in expressions to a sig fig
+# with infinite precision.
+
+sub promote {
+	my $self    = shift;
+	my $context = (Value::isContext($_[0]) ? shift : $self->context);
+	my $value   = (scalar(@_)              ? shift : $self);
+	return $value->inContext($context) if Value::isValue($value) && $value->{sigfigs};
+	return $self->new($context, $value, sigfigs => 'inf');
+}
+
 # The compare method determines that the values are equal with the same number of significant figures.
 # This also handles inequalities as in other Reals.
 

--- a/t/contexts/significant_figures.t
+++ b/t/contexts/significant_figures.t
@@ -385,10 +385,24 @@ subtest 'Division' => sub {
 
 };
 
-# subtest 'Significant Figures for integers' => sub {
-# 	# my $a1 = Compute('1.0 * 10^2');
-# 	my $a1 = Compute('1.0E+02');
-# 	is $a1->format('E'), '1.0E+02', '1.0 * 10^2 internally is 1.0E+02';
-# };
+subtest 'Significant Figures for integers' => sub {
+	# my $a1 = Compute('1.0 * 10^2');
+	my $a1 = Compute('1.0E+02');
+	is $a1->format('E'), '1.0E+02', '1.0 * 10^2 internally is 1.0E+02';
+};
+
+# The following is used the test if an expression (like an average) has a non sig fig
+# perl number to get promoted to a sig fig with infinite precision.
+
+sub ave {
+	my $sum = 0;
+	$sum += $_ for (@_);
+	return $sum / @_;
+}
+
+subtest 'Check promotion rules' => sub {
+	is ave(3.11,       10.49,       6.72),       6.77333333333333, 'check perl averages';
+	is ave(Real(3.11), Real(10.49), Real(6.72)), 6.773,            'check average with sig fig';
+};
 
 done_testing();


### PR DESCRIPTION
As noted in https://github.com/pstaabp/pg/pull/25#issuecomment-2954228114 @dpvc noted that if SigFigs are passed to subroutines that have non-sigfig numbers that those other numbers will be promoted to sig figs.  In general, this is not what is wanted (see the average function in the link above.) 

This adds a promote to the SignificantFigures::Real package that will promote non-sig fig numbers to have infinite sig figs. 