### PR TITLE
Sigfig exponential form

### DIFF
--- a/macros/contexts/contextSignificantFigures.pl
+++ b/macros/contexts/contextSignificantFigures.pl
@@ -324,11 +324,11 @@ sub neg {
 # with infinite precision.
 
 sub promote {
-       my $self    = shift;
-       my $context = (Value::isContext($_[0]) ? shift : $self->context);
-       my $value   = (scalar(@_)              ? shift : $self);
-       return $value->inContext($context) if Value::isValue($value) && $value->{sigfigs};
-       return $self->new($context, $value, sigfigs => 'inf');
+	my $self    = shift;
+	my $context = (Value::isContext($_[0]) ? shift : $self->context);
+	my $value   = (scalar(@_)              ? shift : $self);
+	return $value->inContext($context) if Value::isValue($value) && $value->{sigfigs};
+	return $self->new($context, $value, sigfigs => 'inf');
 }
 
 # The compare method determines that the values are equal with the same number of significant figures.
@@ -349,15 +349,15 @@ sub round {
 
 sub ROUND {
 	my ($x, $n) = @_;
-	return $x + 0 if $n == 'inf';                      # keep the same if infinite digits
-	return 0      if $n < 0 || $x == 0;                # 0 if less than 0 digits wanted or there are no digits
-	my $N = main::max(0, $n - 1);                      # Number of decimals to use in E notation
-	my $r = sprintf("%.${N}E", $x);                    # preliminary rounding of $x
-	my $e = (split(/E/, $r))[1] + 0;                   # exponent for $r
-	my $s = ($x < 0 ? -1 : 1);                         # sign of $x
-	my $m = main::max($n, 14 - $n);                    # position to use for adjustment for repeated 9s
-	$x += $s * 10**($e - $m);                          # adjust for repeated 9s
-	return sprintf("%.${N}E", $x) + 0 unless $n == 0;  # if we want digits, re-round the adjusted value
+	return $x + 0 if $n == 'inf';                        # keep the same if infinite digits
+	return 0      if $n < 0 || $x == 0;                  # 0 if less than 0 digits wanted or there are no digits
+	my $N = main::max(0, $n - 1);                        # Number of decimals to use in E notation
+	my $r = sprintf("%.${N}E", $x);                      # preliminary rounding of $x
+	my $e = (split(/E/, $r))[1] + 0;                     # exponent for $r
+	my $s = ($x < 0 ? -1 : 1);                           # sign of $x
+	my $m = main::max($n, 14 - $n);                      # position to use for adjustment for repeated 9s
+	$x += $s * 10**($e - $m);                            # adjust for repeated 9s
+	return sprintf("%.${N}E", $x) + 0 unless $n == 0;    # if we want digits, re-round the adjusted value
 
 	# For zero digits, we add a digit just above the first one in $x,
 	# round that, then remove the added digit, getting 0 if $x didn't

--- a/macros/contexts/contextSignificantFigures.pl
+++ b/macros/contexts/contextSignificantFigures.pl
@@ -151,17 +151,18 @@ sub new {
 	my ($value, %opts) = @_;
 	my $n = $opts{sigfigs};
 
+	if (!Value::isValue($value) && !Value::matchNumber($value)) {
+		$value = Value::makeValue($value, context => $context);
+		return $value if Value::isFormula($value);
+		Value::Error("Can't convert %s to %s", Value::showClass($value), Value::showClass($self))
+			unless Value::isNumber($value);
+	}
+	return $value->eval if Value::isFormula($value);
 	if (Value::isValue($value) && $value->{sigfigs}) {
 		my $copy = $value->copy->inContext($context);
 		$copy->sigfigs($n) if defined($n) && $n != $copy->N;
 		return $copy;
 	}
-	if (!Value::matchNumber($value)) {
-		$value = Value::makeValue($value, context => $context);
-		return $value if Value::isFormula($value);
-		Value::Error("Can't convert %s to %s", Value::showClass($value), Value::showClass($self));
-	}
-	return $value->eval if Value::isFormula($value);
 
 	if (!defined $n) {
 		my $digits = $value;
@@ -184,6 +185,7 @@ sub new {
 	$value           = $self->format('E', $self->value, $N) unless $N eq 'inf';
 	$self->{exp}     = $N eq 'inf' ? 0 : (split(/E/, $value))[1] + 0;
 	$self->{sigfigs} = $N;
+	$self->{pure}    = 1 unless $opts{computed} || $self->{value}{hadParens};
 
 	return $self;
 }
@@ -216,12 +218,20 @@ sub expFor {
 }
 
 #  Stringify and TeXify the number in the context's base
-sub string { shift->format('f') }
+
+sub string {
+	my ($self, $equation, $precedence) = @_;
+	my $string = $self->format($self->{expForm} || $self->getFlag('alwaysExponentialForm') ? 'E' : 'f');
+	$string        =~ s/E(?:(-)|\+)0*(\d+)/x10^$1$2/;
+	$string        =~ s/\^-(.*)/^(-$1)/;
+	return $string =~ m/x/ && $precedence ? "($string)" : $string;
+}
 
 sub TeX {
-	my $tex = shift->string;
-	$tex =~ s/E(?:(-)|\+)0*([1-9]\d?)/\\times 10^{$1$2}/;
-	return "{$tex}";
+	my ($self, $equation, $precedence) = @_;
+	my $tex = $self->format($self->{expForm} || $self->getFlag('alwaysExponentialForm') ? 'E' : 'f');
+	$tex =~ s/E(?:(-)|\+)0*(\d+)/\\times 10^{$1$2}/;
+	return $tex =~ m/\\times/ && $precedence ? "\\left($tex\\right)" : "{$tex}";
 }
 
 # Format the number in $value in either 'E' (exponential form) or 'f' decimal form using
@@ -237,10 +247,12 @@ sub format {
 	return "$value" if $n == 'inf';
 	$value = ROUND($value, 0) if $n == 0;
 	my $exp = $self->E // $self->expFor($value, 0);
-	$f = 'E' if $f eq 'f' && ($n < 1 || $exp >= 5 || -5 >= $exp);
+	$f = 'E' if $f eq 'f' && ($n - $exp < 1 || $exp >= 5 || -5 >= $exp);
 	$n -= $exp if $f eq 'f';
-	$n = main::max(0, $n - 1);
-	return sprintf("%.${n}${f}" . ($n == 0 && $f eq 'f' ? '.' : ''), $value);
+	$n     = main::max(0, $n - 1);
+	$value = sprintf("%.${n}${f}", $value);
+	$value .= '.' if $n == 0 && $f eq 'f' && $value =~ m/0$/;
+	return $value;
 }
 
 # Redefine addition.  The leftmost signifcant place in the result is needed to get the
@@ -250,7 +262,7 @@ sub add {
 	my ($self, $l, $r, $other) = Value::checkOpOrderWithPromote(@_);
 	my $exp   = main::min($l->N - $l->E, $r->N - $r->E);
 	my $value = $l->round($exp) + $r->round($exp);
-	return $self->new($value, sigfigs => main::max(0, $exp + $self->expFor($value, $exp)));
+	return $self->new($value, sigfigs => main::max(0, $exp + $self->expFor($value, $exp)), computed => 1);
 }
 
 # Redefine subtraction.  The leftmost signifcant place in the result is needed to get the
@@ -260,7 +272,7 @@ sub sub {
 	my ($self, $l, $r, $other) = Value::checkOpOrderWithPromote(@_);
 	my $exp   = main::min($l->N - $l->E, $r->N - $r->E);
 	my $value = $l->round($exp) - $r->round($exp);
-	return $self->new($value, sigfigs => main::max(0, $exp + $self->expFor($value, $exp)));
+	return $self->new($value, sigfigs => main::max(0, $exp + $self->expFor($value, $exp)), computed => 1);
 }
 
 # Redefine multiplication.  Use the product of the two numbers and set the number of significant
@@ -268,7 +280,7 @@ sub sub {
 
 sub mult {
 	my ($self, $l, $r, $other) = Value::checkOpOrderWithPromote(@_);
-	return $self->new($l->value * $r->value, sigfigs => main::min($l->{sigfigs}, $r->{sigfigs}));
+	return $self->new($l->value * $r->value, sigfigs => main::min($l->{sigfigs}, $r->{sigfigs}), computed => 1);
 }
 
 # Redefine multiplication.  Use the quotient of the two numbers and set the number of significant
@@ -276,14 +288,29 @@ sub mult {
 
 sub div {
 	my ($self, $l, $r, $other) = Value::checkOpOrderWithPromote(@_);
-	return $self->new($l->value / $r->value, sigfigs => main::min($l->{sigfigs}, $r->{sigfigs}));
+	return $self->new($l->value / $r->value, sigfigs => main::min($l->{sigfigs}, $r->{sigfigs}), computed => 1);
+}
+
+# Redefine powers.  Record whether this is an integer power of 10 for use with exponetial form.
+
+sub power {
+	my ($self, $l, $r, $other) = Value::checkOpOrderWithPromote(@_);
+	my ($L, $R) = ($l->value, $r->value);
+	$self->Error("Can't raise a negative number to a non-integer power") if $L < 0  && CORE::int($R) != $R;
+	$self->Error("Zero to the zero power is undefined")                  if $L == 0 && $R == 0;
+	return $l->copy                                                      if $L == 0;
+	my $intPower = CORE::int($R) == $R;
+	my $n        = $intPower ? $l->{sigfigs} : main::min($l->{sigfigs}, $r->{sigfigs});
+	my $result   = $self->make($L**$R, sigfigs => $n, computed => 1);
+	$result->{tenPower} = 1 if $intPower && $L == 10 && $l->{pure} && $r->{pure};
+	return $result;
 }
 
 # Redefine abs to return the absolute value of the number with the same number of sigfigs.
 
 sub abs {
 	my $self = shift;
-	return $self->make(CORE::abs($self->value), sigfigs => $self->{sigfigs});
+	return $self->make(CORE::abs($self->value), sigfigs => $self->{sigfigs}, computed => 1);
 }
 
 # Redefined neg to handle the parsing of negative numbers with sigfigs.
@@ -297,11 +324,11 @@ sub neg {
 # with infinite precision.
 
 sub promote {
-	my $self    = shift;
-	my $context = (Value::isContext($_[0]) ? shift : $self->context);
-	my $value   = (scalar(@_)              ? shift : $self);
-	return $value->inContext($context) if Value::isValue($value) && $value->{sigfigs};
-	return $self->new($context, $value, sigfigs => 'inf');
+       my $self    = shift;
+       my $context = (Value::isContext($_[0]) ? shift : $self->context);
+       my $value   = (scalar(@_)              ? shift : $self);
+       return $value->inContext($context) if Value::isValue($value) && $value->{sigfigs};
+       return $self->new($context, $value, sigfigs => 'inf');
 }
 
 # The compare method determines that the values are equal with the same number of significant figures.
@@ -322,15 +349,15 @@ sub round {
 
 sub ROUND {
 	my ($x, $n) = @_;
-	return $x + 0 if $n == 'inf';                        # keep the same if infinite digits
-	return 0      if $n < 0 || $x == 0;                  # 0 if less than 0 digits wanted or there are no digits
-	my $N = main::max(0, $n - 1);                        # Number of decimals to use in E notation
-	my $r = sprintf("%.${N}E", $x);                      # preliminary rounding of $x
-	my $e = (split(/E/, $r))[1] + 0;                     # exponent for $r
-	my $s = ($x < 0 ? -1 : 1);                           # sign of $x
-	my $m = main::max($n, 14 - $n);                      # position to use for adjustment for repeated 9s
-	$x += $s * 10**($e - $m);                            # adjust for repeated 9s
-	return sprintf("%.${N}E", $x) + 0 unless $n == 0;    # if we want digits, re-round the adjusted value
+	return $x + 0 if $n == 'inf';                      # keep the same if infinite digits
+	return 0      if $n < 0 || $x == 0;                # 0 if less than 0 digits wanted or there are no digits
+	my $N = main::max(0, $n - 1);                      # Number of decimals to use in E notation
+	my $r = sprintf("%.${N}E", $x);                    # preliminary rounding of $x
+	my $e = (split(/E/, $r))[1] + 0;                   # exponent for $r
+	my $s = ($x < 0 ? -1 : 1);                         # sign of $x
+	my $m = main::max($n, 14 - $n);                    # position to use for adjustment for repeated 9s
+	$x += $s * 10**($e - $m);                          # adjust for repeated 9s
+	return sprintf("%.${N}E", $x) + 0 unless $n == 0;  # if we want digits, re-round the adjusted value
 
 	# For zero digits, we add a digit just above the first one in $x,
 	# round that, then remove the added digit, getting 0 if $x didn't
@@ -346,6 +373,12 @@ package context::SignificantFigures;
 
 sub Init {
 	my $context = $main::context{SignificantFigures} = context::SignificantFigures::Context->new();
+	$context         = $main::context{LimitedSignificantFigures} = $context->copy;
+	$context->{name} = 'LimitedSignificantFigures';
+	$context->parens->undefine('|', '{', '[');
+	$context->variables->remove('x');
+	$context->operators->undefine('-', '+', '/', '//', ' /', '/ ', '!', '_', '.', 'U', '><');
+	$context->flags->set(limitedSigFigs => 1);
 }
 
 package context::SignificantFigures::Context;
@@ -355,14 +388,44 @@ sub new {
 	my $self    = shift;
 	my $class   = ref($self) || $self;
 	my $context = bless Parser::Context->getCopy('Numeric'), $class;
-	$context->{name}           = 'SignificantFigures';
-	$context->{parser}{Number} = 'context::SignificantFigures::Number';
-	$context->{value}{Real}    = 'context::SignificantFigures::Real';
+	$context->{name}             = 'SignificantFigures';
+	$context->{parser}{Number}   = 'context::SignificantFigures::Number';
+	$context->{parser}{Value}    = 'context::SignificantFigures::Value';
+	$context->{parser}{Variable} = 'context::SignificantFigures::Variable';
+	$context->{value}{Real}      = 'context::SignificantFigures::Real';
 	$context->functions->disable('All');
 	$context->constants->clear();
-	$context->{precedence}{SignifcantFigures} = $context->{precedence}{special};
-	$context->flags->set(limits => [ -1000, 1000, 1 ]);
-
+	$context->{precedence}{SignificantFigures} = $context->{precedence}{special};
+	$context->flags->set(alwaysExponentialForm => 0);    # controls whether all reals are given in exponential form
+	$context->operators->set(
+		'*'  => { class => 'context::SignificantFigures::BOP::multiply' },
+		'* ' => { class => 'context::SignificantFigures::BOP::multiply' },
+		' *' => { class => 'context::SignificantFigures::BOP::multiply' },
+		'^'  => { class => 'context::SignificantFigures::BOP::power' },
+		'**' => { class => 'context::SignificantFigures::BOP::power' },
+		' '  => { class => 'context::SignificantFigures::BOP::space', space => '  ', string => '  ' },
+		'  ' =>
+			{ %{ $context->operators->get('*') }, class => 'context::SignificantFigures::BOP::space', hidden => 1 },
+		'u-' => { class => 'context::SignificantFigures::UOP::minus' },
+		'u+' => { class => 'context::SignificantFigures::UOP::plus' },
+	);
+	#
+	# Arrange for variables to be higher priority than operators so variable 'x' is used rather
+	# than operator 'x', unless the variable is removed.
+	#
+	my $variables = '_' . $context->variables->{dataName};
+	$context->{data}{objects} = [ (grep { $_ ne $variables } @{ $context->{data}{objects} }), $variables ];
+	#
+	# Add the 'x' operator as a fallback when 'x' is not a variable.
+	#
+	$context->operators->set(
+		'x' => {
+			%{ $context->operators->get('*') },
+			class  => 'context::SignificantFigures::BOP::multiply',
+			string => 'x',
+			TeX    => '\\times'
+		},
+	);
 	return $context;
 }
 
@@ -375,8 +438,79 @@ sub checkSigFigs {
 	return main::max(1, $n);
 }
 
+# Some common function for the Parser object overrides
+
+package context::SignificantFigures::common;
+
+# True when this is a pure real, not a computed one
+
+sub isPure {
+	my ($self, $value) = @_;
+	return $value->{pure} && !$value->{hadParens};
+}
+
+# Check for limited use of UOPs
+
+sub checkLimitedUOP {
+	my $self = shift;
+	Value::Error("You can only use '%s' on an unsigned constant", shift)
+		if $self->context->flag('limitedSigFigs') && !$self->{pure};
+}
+
+# Check whether multiplication is for exponential form
+
+sub checkExponentialForm {
+	my $self = shift;
+	my ($l, $r) = ($self->{lop}, $self->{rop});
+	if ($r->{tenPower} && !$r->{hadParens} && $self->isPure($l)) {
+		$r                   = $r->{lop} if $r->class eq 'BOP';
+		$r->{value}{sigfigs} = 'inf';
+		$self->{expForm}     = 1;
+		$self->{def}         = { %{ $self->{def} }, string => 'x', TeX => '\times' };
+	} else {
+		Value::Error("The '%s' operator can ony appear between a simple constant and an integer power of ten",
+			$self->{bop})
+			if $self->context->flag('limitedSigFigs') || $self->{bop} eq 'x';
+	}
+}
+
+# Copy the special properites used for exponential notation processing
+
+sub COPY {
+	my ($self, $from, $to) = @_;
+	for my $name ('pure', 'hadParens', 'hadPlus', 'tenPower', 'expForm') {
+		delete $to->{name} if $to->{$name};
+		$to->{$name} = 1   if $from->{$name};
+	}
+	delete $to->{pure} if $to->{hadParens};
+	return $to;
+}
+
+# Properly handle constants in exponential form, and add parenthese if needed
+
+sub STRING {
+	my ($self, $fn, $precedence) = @_;
+	my $flags  = Value::contextSet($self->context, alwaysExponentialForm => 0);
+	my $string = $self->{expForm} && $precedence ? $self->addParens(&$fn) : &$fn;
+	Value::contextSet($self->context, %$flags);
+	return $string;
+}
+
+# Properly handle constants in exponential form, and add parenthese if needed
+
+sub TEX {
+	my ($self, $fn, $precedence) = @_;
+	my $flags = Value::contextSet($self->context, alwaysExponentialForm => 0);
+	my $tex   = $self->{expForm} && $precedence ? '\left(' . &$fn . '\right)' : &$fn;
+	Value::contextSet($self->context, %$flags);
+	return $tex;
+}
+
+# Override Parser::Number to handle SignificantFigures Reals and copy the properties
+# needed for processing exponential form.
+
 package context::SignificantFigures::Number;
-our @ISA = ('Parser::Number');
+our @ISA = ('Parser::Number', 'context::SignificantFigures::common');
 
 sub new {
 	my $self  = shift;
@@ -387,14 +521,203 @@ sub new {
 	$self = bless $self->SUPER::new($equation, $x, $ref), $class;
 	$self->{value} = Value::isValue($x)
 		&& $x->{sigfigs} ? $x->copy->inContext($context) : $self->Package('Real')->new($context, $self->{value_string});
-	return $self;
+	return $self->COPY($self->{value}, $self);
+}
+
+sub class {'Number'}
+
+sub value { shift->{value}->value }
+
+sub eval {
+	my $self = shift;
+	return $self->COPY($self, $self->SUPER::eval(@_));
 }
 
 sub perl {
 	my $self  = shift;
 	my $value = $self->{value};
 	return $self->SUPER::perl unless $value->{sigfigs};
-	return $self->context->Package('Real') . '->new(' . $value->value . ',' . $value->N . ')';
+	return $self->context->Package('Real') . '->new(' . $value->value . ', sigfigs => {' . $value->N . '})';
+}
+
+# Override the Parser::Value class to avoid using CORE::abs that would otherwise
+# mark the result as computed when it may be pure
+
+package context::SignificantFigures::Value;
+our @ISA = ('Parser::Value');
+
+sub new {
+	my $self     = shift;
+	my $class    = ref($self) || $self;
+	my $equation = shift;
+	my $context  = $equation->{context};
+	my ($value, $ref) = @_;
+	$value = $value->[0] if ref($value) eq 'ARRAY' && scalar(@{$value}) == 1;
+	return $self->SUPER::new($equation, @_) unless Value::isValue($value) && $value->{sigfigs};
+	return $self->Item("Number")->new($equation, $value);
+}
+
+# Override the Parser::Variable class to count the number of times a variable is used
+# (so we can remove it from the equation's variables if 'x' is used for exponential form)
+
+package context::SignificantFigures::Variable;
+our @ISA = ('Parser::Variable');
+
+sub new {
+	my $self = shift;
+	my $v    = $self->SUPER::new(@_);
+	my ($equation, $name) = ($v->{equation}, $v->{name});
+	$equation->{vCount}{$name} = 0 unless defined $equation->{vCount}{$name};
+	$equation->{vCount}{$name}++;
+	return $v;
+}
+
+sub class {'Variable'}
+
+# Override Parser::UOP::minus to allow negation of a constant, but mark
+# any other usage as computed rather than pure
+
+package context::SignificantFigures::UOP::minus;
+our @ISA = ('Parser::UOP::minus', 'context::SignificantFigures::common');
+
+sub _check {
+	my $self = shift;
+	$self->SUPER::_check(@_);
+	my $op = $self->{op};
+	$self->{pure} = 1 if $op->class eq 'Number' && $self->isPure($op) && !$op->{hadPlus};
+	$self->checkLimitedUOP('-');
+}
+
+sub _eval {
+	my $self = shift;
+	return $self->COPY($self, $self->SUPER::_eval(@_));
+}
+
+# Override the Parser::UOP::plus to allow it to be used on a constant, but
+# mark any other usage as computed rather than pure
+
+package context::SignificantFigures::UOP::plus;
+our @ISA = ('Parser::UOP::plus', 'context::SignificantFigures::common');
+
+sub _check {
+	my $self = shift;
+	$self->SUPER::_check(@_);
+	my $op = $self->{op};
+	$self->{pure}    = 1 if $op->class eq 'Number' && $self->isPure($op) && !$op->{hadPlus};
+	$self->{hadPlus} = 1;
+	$self->checkLimitedUOP('+');
+}
+
+sub _eval {
+	my $self = shift;
+	return $self->COPY($self, $self->SUPER::_eval(@_)->with(hadPlus => 1));
+}
+
+# Override Parser::BOP::mulitoply to handle the formation of an exponential form
+
+package context::SignificantFigures::BOP::multiply;
+our @ISA = ('Parser::BOP::multiply', 'context::SignificantFigures::common');
+
+sub _check {
+	my $self = shift;
+	$self->SUPER::_check(@_);
+	$self->checkExponentialForm;
+}
+
+sub _eval {
+	my $self = shift;
+	return $self->COPY($self, $self->SUPER::_eval(@_));
+}
+
+sub string {
+	my $self = shift;
+	return $self->STRING(sub { $self->SUPER::string }, @_);
+}
+
+sub TeX {
+	my $self = shift;
+	return $self->TEX(sub { $self->SUPER::TeX }, @_);
+}
+
+# Override implicit multiplication to form exponential form when we have
+# a number (implicitly) times the 'x' (implicitly) times a power of 10.
+
+package context::SignificantFigures::BOP::space;
+our @ISA = ('Parser::BOP::multiply', 'context::SignificantFigures::common');
+
+sub _check {
+	my $self = shift;
+	$self->SUPER::_check(@_);
+	Value::Error("Can't use implied multiplication in this context") if $self->context->flag('limitedSigFigs');
+	my ($l, $r) = ($self->{lop}, $self->{rop});
+	return unless $r->{tenPower} && !$r->{hadParens} && $l->class eq 'BOP' && $l->{bop} eq '  ';
+	my ($L, $R) = ($l->{lop}, $l->{rop});
+	if ($R->class eq 'Variable' && $R->{name} eq 'x' && $self->isPure($L)) {
+		#
+		# Mark the 10 as infinite precision and remove the 'x' and its multiplication,
+		# leaving only the number and the power of ten being multiplied.
+		#
+		$r                   = $r->{lop} if $r->class eq 'BOP';
+		$r->{value}{sigfigs} = 'inf';
+		$self->{lop}         = $l->{lop};
+		$self->{isConstant}  = 1;
+		$self->{expForm}     = 1;
+		#
+		# Set the string and TeX values for exponential form.
+		#
+		$self->{def} = { %{ $self->{def} }, string => 'x', TeX => '\times' };
+		#
+		# Remove the variable from the expression if this was the only occurrance of 'x'.
+		#
+		my $equation = $self->{equation};
+		$equation->{vCount}{x}--;
+		delete $equation->{variables}{x} if $equation->{vCount}{x} == 0;
+	}
+}
+
+sub eval {
+	my $self = shift;
+	return $self->COPY($self, $self->SUPER::eval(@_));
+}
+
+sub string {
+	my $self = shift;
+	return $self->STRING(sub { $self->SUPER::string }, @_);
+}
+
+sub TeX {
+	my $self = shift;
+	return $self->TEX(sub { $self->SUPER::TeX }, @_);
+}
+
+# Override Parser::BOP::power to mark occurances of ten-to-a-power so we can
+# recognize them when checking for exponential form
+
+package context::SignificantFigures::BOP::power;
+our @ISA = ('Parser::BOP::power', 'context::SignificantFigures::common');
+
+sub _check {
+	my $self = shift;
+	$self->SUPER::_check(@_);
+	my ($l, $r) = ($self->{lop}, $self->{rop});
+	delete $r->{hadParens} if $self->isPureParen($r);
+	if ($l->class eq 'Number' && $self->isPure($r)) {
+		my ($L, $R) = ($l->value, $r->eval->value);
+		$self->{tenPower} = 1 if $L == 10 && $self->isPure($l) && CORE::int($R) == $R;
+	}
+	$self->checkLimited();
+}
+
+sub isPureParen {
+	my ($self, $r) = @_;
+	return $r->{hadParens} && $r->{pure} && $r->class eq 'UOP';
+}
+
+sub checkLimited {
+	my $self = shift;
+	return                                                            unless $self->context->flag('limitedSigFigs');
+	Value::Error("Exponents can only be used with a base of 10 here") unless $self->{lop}->value == 10;
+	Value::Error("Exponents can only be integers")                    unless $self->{tenPower};
 }
 
 1;

--- a/t/contexts/significant_figures.t
+++ b/t/contexts/significant_figures.t
@@ -114,7 +114,7 @@ subtest 'Create numbers with significant digits using Real' => sub {
 	is $a9->sigfigs,     4,                       '-12340000 has 4 significant figures';
 	is $a9->E,           7,                       '-12340000 = -1.234 * 10^(7)';
 	is $a9->format('E'), '-1.234E+07',            'Correct exponential/internal form';
-	is $a9->string,      '-1.234x10^7',          'Correct string output.';
+	is $a9->string,      '-1.234x10^7',           'Correct string output.';
 	is $a9->TeX,         '{-1.234\times 10^{7}}', 'Correct TeX output.';
 
 	ok my $a10 = Compute('0.00000001234'), 'Creating the number 0.00000001234';

--- a/t/contexts/significant_figures.t
+++ b/t/contexts/significant_figures.t
@@ -93,15 +93,15 @@ subtest 'Create numbers with significant digits using Real' => sub {
 	is $a6->sigfigs,     3,                     '1230000 has 3 significant figures.';
 	is $a6->E,           6,                     '1230000 = 1.23 * 10^6';
 	is $a6->format('E'), '1.23E+06',            'Correct exponential/internal form of 1230000';
-	is $a6->string,      '1.23E+06',            'Correct string output of 1230000';
+	is $a6->string,      '1.23x10^6',           'Correct string output of 1230000';
 	is $a6->TeX,         '{1.23\times 10^{6}}', 'Correct TeX output of 1230000';
 
 	ok my $a7 = Compute('2'), 'Create the number 2';
 	is $a7->sigfigs,     1,       '2 has 1 significant figure.';
 	is $a7->E,           0,       '2 = 2 * 10^0';
 	is $a7->format('E'), '2E+00', 'Correct exponential/internal form of 2';
-	is $a7->string,      '2.',    'Correct string output of 2';
-	is $a7->TeX,         '{2.}',  'Correct TeX output of 2';
+	is $a7->string,      '2',     'Correct string output of 2';
+	is $a7->TeX,         '{2}',   'Correct TeX output of 2';
 
 	ok my $a8 = Compute('-1.932'), 'Creating the number -1.932';
 	is $a8->sigfigs,     4,            '-1.932 has 4 significant figures.';
@@ -114,14 +114,14 @@ subtest 'Create numbers with significant digits using Real' => sub {
 	is $a9->sigfigs,     4,                       '-12340000 has 4 significant figures';
 	is $a9->E,           7,                       '-12340000 = -1.234 * 10^(7)';
 	is $a9->format('E'), '-1.234E+07',            'Correct exponential/internal form';
-	is $a9->string,      '-1.234E+07',            'Correct string output.';
+	is $a9->string,      '-1.234x10^7',          'Correct string output.';
 	is $a9->TeX,         '{-1.234\times 10^{7}}', 'Correct TeX output.';
 
 	ok my $a10 = Compute('0.00000001234'), 'Creating the number 0.00000001234';
 	is $a10->sigfigs,      4,                      '0.00000001234 has 4 significant figures';
 	is $a10->E,           -8,                      '0.00000001234 = 1.234 * 10^(-11)';
 	is $a10->format('E'), '1.234E-08',             'Correct exponential/internal form';
-	is $a10->string,      '1.234E-08',             'Correct string output.';
+	is $a10->string,      '1.234x10^(-8)',         'Correct string output.';
 	is $a10->TeX,         '{1.234\times 10^{-8}}', 'Correct TeX output.';
 
 	ok my $a11 = Real('10', sigfigs => 'inf'), 'Creating the number 10 with infinite sigfigs.';


### PR DESCRIPTION
Here is an update to add the ability to enter numbers in exponential form, e.g., `1.23x10^4`.  This took a bit of machinery to make it work, as one has to override most of the operators in order to be able to track when operands are simple numbers as opposed to when they are computations or had parentheses that were removed, etc.  It also involves overriding several other Parser classes so that the markers can be properly maintained as the numbers move through the parse tree in various ways.

This implementation allows `x` to be used as both an operator for `1.23x10^4` as well as a variable (for when you eventually allow significant figures in formulas).  The idea is that `1.23x10^4` is usually interpreted as `1.23*x*10^4` via implicit multiplication, so we override the implicit multiplication operator to look for `1.23*x` (with implicit multiplication) on the left and `10^4` on the right, and then it removes the `*x` on the left to get `1.23*10^4` and marks it as exponential form so that it stringifies as `1.23x10^4` and is treated as a single number.

If `x` gets removed as a variable, then the `x` operator comes into play, and is treaded as *.

That is the basic idea, but there are a bunch of subtleties, especially in tracking what is a pure number and what is a computed number.  The processing of exponential form is strict about the left-hand operand being a simple number (not a computation) and the right-hand being a constant 10 raised to an integer power (again not computed).  Having parentheses counts as being a computation, so `(1.23)x10^4` would not produce an exponential form, nor would `1.23x10^(4)` or `1.23x(10)^4`, or `1.23x10^--2`.  The only exception is that parentheses are allowed around a negative exponent:  `1.23x10^(-4)`.  The left-hand number can be any number, so `12.3x10^4` is also allowed.

The string and TeX output functions have been modified to allow printing of numbers in exponential form, so a number entered that was will always print in exponential form, and the string version will be `1.23x10^4` rather than `1.23E+04` (though you can use either form to enter the number).  There is also a new content flag, `alwaysExponentialForm` that controls whether to print *all* reals in exponential form (off by default).

I modified your `LimitedSignificantFigures` context to use these new features to allow exponential form in the limited setting, and to handle the issue of negation that I mentioned earlier.

I didn't add any tests, but there should be a lot more to test the new notation and the limited context.  There should also be tests using `reduceConstants => 0`, since that requires the parser to handle `x` and the other operators differently, so tests should be made for both settings of `reduceConstants`.

Finally, I didn't modify the POD documentation, so you will need to add the new exponential form there yourself.

As for the details of the changes, the modifications in `SignificantFigures::Real->new()` are to move the check for an existing Real to after the coercion to a Value object by `Value::makeValue()`, so that if that produces a Real (say from passing a string that reduces to a number rather than a number itself), we handle it as we would have if it were passed to `new()` directly.  (This was a bug before, but I didn't catch it.)  It also marks the result as `pure` when that is appropriate.

The `string()` and `TeX()` functions now add parentheses when the result contains exponential form and the number is being used in a larger expression (so that it is treated as a unit).  That means that `2^(1.2x10^-3)` will not become `2^1.2x10^3` which would be interpreted as `(2^3)x10^3`, producing a error (the left-hand operand of `x` must be a simple number).

The `format()` was actually producing some incorrect results, which are addressed here.  First, the wrong condition was being used to convert an `f` format to `E`, which is fixed in (new) line 250.  It also was adding a `.` too aggressively.  It should only add it when the result is an integer having exactly the number of significant digits as total digits.  That is fixed here.

The computation functions are modified to mark the results as being computed values (so *not* pure numbers), which is part of the tracking of computations so that exponential form can be processed properly.  A `power()` method is added to handle exponentiation (mostly for `10^n`, but also allows other exponentials).

The rest of the changes are basically just new code to handle the exponential form as described above.  There are some comments indicating the most important parts, but mostly is not all that interesting.

In any case, I think this implements what you are trying to do in your #27 and #30 (and builds on your #25).
