### PR TITLE
Create a separate SignificantFiguresUnits context

### DIFF
--- a/macros/contexts/contextSignificantFiguresUnits.pl
+++ b/macros/contexts/contextSignificantFiguresUnits.pl
@@ -1,0 +1,48 @@
+
+BEGIN { strict->import }
+
+loadMacros('contextUnits.pl', 'contextSignificantFigures.pl');
+
+sub _contextSignificantFiguresUnits_init {
+	context::SignificantFiguresUnits::Init(@_);
+}
+
+package context::SignificantFiguresUnits::NumberWithUnit;
+our @ISA = ('context::Units::NumberWithUnit');
+
+# call the postprocess for handling error messages and flags. 
+# This needs to be called for the SignificantFigure and Units separately. 
+
+sub cmp_postprocess {
+	my ($self, $ansHash) = @_;
+	warn $ansHash->{student_value}->type;
+	warn ref $self->unit;
+	$self->SUPER::cmp_postprocess($ansHash);
+	# $self->unit->cmp_postprocess($ansHash);
+
+	# Since the current $ansHash has the correct and student value as the NumberWithUnits type
+	# pass in just the number (SignificantFigure) to the postprocess. 
+	my $correct_value = $ansHash->{correct_value};
+	my $student_value = $ansHash->{student_value};
+	$ansHash->{correct_value} = $correct_value->number;
+	$ansHash->{student_value} = $student_value->number;
+	$self->SUPER::cmp_postprocess($ansHash);
+	$ansHash->{correct_value} = $correct_value;
+	$ansHash->{student_value} = $student_value;
+}
+
+package context::SignificantFiguresUnits;
+
+sub Init {
+	my $context = $main::context{SignificantFiguresUnits} = context::Units::extending('SignificantFigures');
+	$context->{value}{NumberWithUnit}     = 'context::SignificantFiguresUnits::NumberWithUnit';
+	$context->{value}{'Number-with-Unit'} = 'context::SignificantFiguresUnits::NumberWithUnit';
+	$context                              = $main::context{LimitedSignificantFiguresUnits} = $context->copy;
+	$context->{name}                      = 'LimitedSignificantFiguresUnits';
+	$context->parens->undefine('|', '{', '[');
+	$context->variables->remove('x');
+	$context->operators->undefine('-', '+', '/', '//', ' /', '/ ', '!', '_', '.', 'U', '><');
+	$context->flags->set(limitedSigFigs => 1);
+}
+
+1;

--- a/macros/contexts/contextUnits.pl
+++ b/macros/contexts/contextUnits.pl
@@ -1446,7 +1446,9 @@ sub cmp_defaults { () }
 sub cmp_postprocess {
 	my ($self, $ans) = @_;
 	my $student = $ans->{student_value};
-	return unless defined($student) && $student->type eq 'Unit';
+	warn 'in Units::cmp_postprocess';
+	warn $student->type;
+	return unless defined($student) && $student->type =~ /Unit/;
 	return                                              if $ans->{ans_message};
 	$self->cmp_Error($ans, "Your units aren't correct") if $self->fString ne $student->fString;
 	return                                              if $ans->{score} != 1 || !$self->getFlag('exactUnits');
@@ -1725,6 +1727,8 @@ sub cmp_defaults { () }
 sub cmp_postprocess {
 	my ($self, $ans) = @_;
 	my $student = $ans->{student_value};
+	warn 'in NumberWithUnits::cmp_postprocess';
+	warn $student->type;
 	return unless defined($student) && $student->type eq $context::Units::NUNIT;
 	return                                              if $ans->{ans_message};
 	$self->cmp_Error($ans, "Your units aren't correct") if $self->fString ne $student->fString;

--- a/t/contexts/significant_figures_units.t
+++ b/t/contexts/significant_figures_units.t
@@ -42,4 +42,78 @@ subtest 'Test a number with length units and significant figures' => sub {
 	ok $a == Compute('4.036 ft'), 'Value in feet (a little off, but when converted to m is correct)';
 };
 
+subtest 'redo with new macro' => {
+	Context('SignificantFiguresUnits')->withUnitsFor('length');
+	ok my $a = Compute('123.0 cm'), 'Compute handles a unit.';
+
+	is $a, '123.0 cm', 'Value stringifies with units and sig figs';
+	ok $a == Compute('1.230 m'), 'Value stringifies with correct unit conversion and sig figs';
+	ok $a != Compute('123 cm'),  'Value does not lose significant figure information when stringified';
+
+	ok $a == Compute('4.035 ft'), 'Value in feet';
+	ok $a == Compute('4.034 ft'), 'Value in feet (a little off, but when converted to m is correct)';
+	ok $a == Compute('4.036 ft'), 'Value in feet (a little off, but when converted to m is correct)';
+};
+
+subtest 'Test an actual problem' => sub {
+
+	my $source = <<~'END_SOURCE';
+		DOCUMENT();
+
+		loadMacros("PGstandard.pl","PGML.pl",'contextSignificantFiguresUnits.pl');
+
+		Context('SignificantFiguresUnits')->withUnitsFor('mass');
+
+		Context()->flags->set(
+					tolerance                   => 0.01,
+					partial_incorrect_sf        => 0.6,
+					partial_sf_within_tolerance => 0.8,
+					);
+
+		$a = Compute("123.0 g");
+		$b = Compute("45.3 g");
+		$c = $a+$b;
+
+		BEGIN_PGML
+		A lab technician has a beaker with [$a] of water.  She adds [$b] to the beaker.  Using the proper number of significant figures, what is the total amount in the beaker? 
+
+		[_]{$c}
+		END_PGML
+
+		ENDDOCUMENT();
+	END_SOURCE
+
+	ok my $pg = WeBWorK::PG->new(
+		r_source       => \$source,
+		inputs_ref     => { AnSwEr0001 => '168.3 g' },
+		processAnswers => 1
+		),
+		'source string renders';
+
+	is $pg->{result}{score}, 1, 'correct answer is scored correctly';
+
+	my $pg2 = WeBWorK::PG->new(
+		r_source       => \$source,
+		inputs_ref     => { AnSwEr0001 => '168.30 g' },
+		processAnswers => 1
+	);
+
+	is $pg2->{result}{score}, 0.6, 'check deduction for wrong number of significant figures.';
+	like $pg2->{answers}{AnSwEr0001}{ans_message}, qr/Incorrect number of significant figures/,
+		'Answer processed showing message.';
+
+	my $pg3 = WeBWorK::PG->new(
+		r_source       => \$source,
+		inputs_ref     => { AnSwEr0001 => '168.2 g' },
+		processAnswers => 1
+	);
+
+	is $pg3->{result}{score}, 0.8,
+		'check deduction for right number of significant figures, but answer within tolerance.';
+	like $pg3->{answers}{AnSwEr0001}{ans_message},
+		qr/Correct number of significant figures, but the value is not correct/,
+		'Answer processed showing message.';
+
+};
+
 done_testing;


### PR DESCRIPTION
Recreating #38 because I deleted the branch as it was merged into PG2.21.  See that branch for the beginning of this discussion. 

@dvpc:  from your comment in #38:

> I think you should be calling `$self->SUPER::cmp_postprocess($ansHash)` not the unit's post-processor in order to get the correct tests and messages. You don't want to post-process a student answer that is a number with units against just a unit (the unit `cmp_postprocess()` function returns immediately if the student value isn't a Unit object a number-with-units isn't a Unit.

Is it correct then when calling the sigfig postprocess to do: `	$correct_value->number->cmp_postprocess($ansHash);` ?

Also, @sfiedle noticed that if there are no units there is no message.  My thinking is that if a student puts in a number without a unit that it is parsed as a `SignificantFigures::Real` instead.  I noticed this is the same behavior as using `Units` context.  

Would we just need to add a check in the problem for units?  Or is there a more general way to handle this? 
